### PR TITLE
79 fix analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,25 @@
 
 A simple statically-generated site, implemented in [Metalsmith](http://www.metalsmith.io/).
 
-Currently in beta.
+Currently deprecated.
 
 ### Running locally
 
 - Clone the repo
-- `npm install && bower install`
+- `nvm use`
+- `yarn install`
 - Create a new `.env` file at the project root. (e.g. `touch .env && nano .env`)
 - Add the following keys to `.env` (You'll need to contact the project admin privately for API keys):
 
 ```
 ENV=development
-CONTENTFUL_PREVIEW_ACCESS_TOKEN=<contentful access token>
+CONTENTFUL_ACCESS_TOKEN=<contentful access token>
 CONTENTFUL_SPACE=<contenful space>
+GRAPHQL_ENDPOINT=<endpoint>
 ```
 
-- Build the site using `node index`
-- The site builds to the `./dest` directory --- the simplest way to serve this is to install [http-server](https://www.npmjs.com/package/http-server) globally (`npm install -g http-server`), open a new Terminal tab, `cd ./dest && http-server`. You can leave the server running between builds.
+- Build the site using `yarn build` (run `yarn metalsmith` to only rebuild static while making adjustments during development)
+- The site builds to the `./dest` directory --- the simplest way to serve this is to install [http-server](https://www.npmjs.com/package/http-server) globally (`yarn global add http-server`), open a new Terminal tab, `cd ./dest && http-server`. You can leave the server running between builds.
 
 ### Browserstack thank you
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ A simple statically-generated site, implemented in [Metalsmith](http://www.metal
 
 Currently in beta.
 
-
 ### Running locally
 
 - Clone the repo
 - `npm install && bower install`
 - Create a new `.env` file at the project root. (e.g. `touch .env && nano .env`)
 - Add the following keys to `.env` (You'll need to contact the project admin privately for API keys):
+
 ```
 ENV=development
-CONTENTFUL_ACCESS_TOKEN=<contentful access token>
+CONTENTFUL_PREVIEW_ACCESS_TOKEN=<contentful access token>
 CONTENTFUL_SPACE=<contenful space>
 ```
+
 - Build the site using `node index`
 - The site builds to the `./dest` directory --- the simplest way to serve this is to install [http-server](https://www.npmjs.com/package/http-server) globally (`npm install -g http-server`), open a new Terminal tab, `cd ./dest && http-server`. You can leave the server running between builds.
 

--- a/src/templates/layout.swig
+++ b/src/templates/layout.swig
@@ -28,6 +28,9 @@
 		// enqueue scripts at the end of the page from before the closing body tag
 		window.d=[];window.loadScript=function(path){d.push(path)}
 
+		// For Segment Analytics
+		window.WRITE_CODE = "VtTlzxOC5QJ1H0zermvo84cAbReTofDU"
+
 	</script>
 	{% block head %}
 	{% endblock %}
@@ -116,9 +119,84 @@
 				});
 			})
 			.queueScript('/scripts/app.min.js')
-			.queueScript('https://cdn.segment.com/analytics.js/v1/VtTlzxOC5QJ1H0zermvo84cAbReTofDU/analytics.min.js')
+			.queueWait(function () {
+				/*
+				 * Segment Analytics Preload
+				 * From: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/
+				 * - used unminified on purpose as we need to integrate it with $LAB and keep things readable
+				 */
+				var analytics = window.analytics = window.analytics || [];
+				// If the real analytics.js is already on the page return.
+				if (analytics.initialize) return;
+				// If the snippet was invoked already show an error.
+				if (analytics.invoked) {
+					if (window.console && console.error) {
+					console.error('Segment snippet included twice.');
+					}
+					return;
+				}
+				// Invoked flag, to make sure the snippet
+				// is never invoked twice.
+				analytics.invoked = true;
+				// A list of the methods in Analytics.js to stub.
+				analytics.methods = [
+					'trackSubmit',
+					'trackClick',
+					'trackLink',
+					'trackForm',
+					'pageview',
+					'identify',
+					'reset',
+					'group',
+					'track',
+					'ready',
+					'alias',
+					'debug',
+					'page',
+					'once',
+					'off',
+					'on',
+					'addSourceMiddleware',
+					'addIntegrationMiddleware',
+					'setAnonymousId',
+					'addDestinationMiddleware'
+				];
+				// Define a factory to create stubs. These are placeholders
+				// for methods in Analytics.js so that you never have to wait
+				// for it to load to actually record data. The `method` is
+				// stored as the first argument, so we can replay the data.
+				analytics.factory = function(method){
+					return function(){
+					var args = Array.prototype.slice.call(arguments);
+					args.unshift(method);
+					analytics.push(args);
+					return analytics;
+					};
+				};
+				// For each of our methods, generate a queueing stub.
+				for (var i = 0; i < analytics.methods.length; i++) {
+					var key = analytics.methods[i];
+					analytics[key] = analytics.factory(key);
+				}
+
+			})
+			/* Segment Analytics load */
+			.queueScript('https://cdn.segment.com/analytics.js/v1/'+ window.WRITE_CODE +'/analytics.min.js')
 			.queueWait(function(){
+				/*
+				 * Segment Analytics postload
+				 * Also copied from: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/
+				 */
 				// Segment actions
+				analytics._writeKey = window.WRITE_CODE
+				// Add a version to keep track of what's in the wild.
+				analytics.SNIPPET_VERSION = '4.13.2';
+				// Load Analytics.js with your key, which will automatically
+				// load the tools you've enabled for your account. Boosh!
+				analytics.load(window.WRITE_CODE);
+				// Make the first page call to load the integrations.
+				analytics.page();
+				/* end copy */
 
 				// Segment actions reliant on jQuery
 				(function($){


### PR DESCRIPTION
Closes #79 

- Converted the v2 snippet found on https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/ to work with our LAB script loader
- Tested it locally with `npm run serve`, events are going out if I call `analytics.page()` from the console on the page, but it's a new codebase to me so not 100% sure about implementation

## Notes while getting things up and running

- I guess bower is no longer needed at all so can be removed form the README?
- I had an issue with post-install of metalsmith-concat, found this issue: https://gitmemory.com/issue/aymericbeaumet/metalsmith-concat/36/485764416 with @colophonemes  offering the solution 👯 
- The process envs were wrongly defined in the README, updated that.
- I btw got it running locally without the Contentful stuff by just commenting out the need for contentTypes on the homepage, should probably get the correct keys as well :) 